### PR TITLE
Refactored tests to table driven tests

### DIFF
--- a/test/10.usecase.test.js
+++ b/test/10.usecase.test.js
@@ -7,165 +7,113 @@ const injected = require('../lib/injected');
 describe('Use cases', () => {
   const NODE_ENV = process.env.NODE_ENV;
 
-  describe('With default arguments and test env', () => {
-    let defaults;
+  const testTable = [
+    {
+      env: 'test',
+      defaults: [undefined, 'lorem', undefined, 'lorem', 'ipsum']
+    },
+    {
+      env: 'development',
+      defaults: [undefined, 'lorem', undefined, undefined, 'dolor']
+    },
+    {
+      env: 'staging',
+      defaults: [undefined, 'lorem', undefined, undefined, undefined]
+    },
+    {
+      env: 'production',
+      defaults: [undefined, 'lorem', undefined, undefined, undefined]
+    }
+  ];
 
-    before(() => {
-      process.env.NODE_ENV = 'test';
-      defaults = builder();
-    });
+  describe('defaults', () => {
+    for (var i = 0; i < testTable.length; i++) {
+      const tt = testTable[i];
+      describe(`With default arguments and ${tt.env} env`, () => {
+        let defaults;
 
-    after(() => {
-      process.env.NODE_ENV = NODE_ENV;
-    });
+        before(() => {
+          process.env.NODE_ENV = tt.env;
+          defaults = builder();
+        });
 
-    it('should yield nothing with nothing', () => {
-      should(defaults()).equal(undefined);
-    });
+        after(() => {
+          process.env.NODE_ENV = NODE_ENV;
+        });
 
-    it('should yield string with string', () => {
-      should(defaults('lorem')).equal('lorem');
-    });
+        it('should yield nothing with nothing', () => {
+          should(defaults()).equal(tt.defaults[0]);
+        });
 
-    it('should yield nothing with empty array', () => {
-      should(defaults([])).equal(undefined);
-    });
+        it('should yield string with string', () => {
+          should(defaults('lorem')).equal(tt.defaults[1]);
+        });
 
-    it('should yield value with an array', () => {
-      should(defaults(['lorem'])).equal('lorem');
-    });
+        it('should yield nothing with empty array', () => {
+          should(defaults([])).equal(tt.defaults[2]);
+        });
 
-    it('should yield value with an array', () => {
-      should(defaults(['ipsum', 'dolor'])).equal('ipsum');
-    });
+        it('should yield value with an array', () => {
+          should(defaults(['lorem'])).equal(tt.defaults[3]);
+        });
+
+        it('should yield value with an array', () => {
+          should(defaults(['ipsum', 'dolor'])).equal(tt.defaults[4]);
+        });
+      });
+    }
   });
 
-  describe('With default arguments and development env', () => {
-    let defaults;
+  describe('injected', () => {
+    for (var i = 0; i < testTable.length; i++) {
+      const tt = testTable[i];
+      describe(`The injected with default arguments and ${tt.env} env`, () => {
+        let env;
 
-    before(() => {
-      process.env.NODE_ENV = 'development';
-      defaults = builder();
-    });
+        before(() => {
+          process.env.NODE_ENV = tt.env;
+          env = injected();
+        });
 
-    after(() => {
-      process.env.NODE_ENV = NODE_ENV;
-    });
+        after(() => {
+          process.env.NODE_ENV = NODE_ENV;
+        });
 
-    it('should yield nothing with nothing', () => {
-      should(defaults()).equal(undefined);
-    });
+        it('should yield nothing with nothing', () => {
+          should(env.get('TEST_LOREM').asString()).equal(tt.defaults[0]);
+          process.env.TEST_LOREM = 'test_lorem';
+          should(env.get('TEST_LOREM').asString()).equal('test_lorem');
+          delete process.env.TEST_LOREM;
+        });
 
-    it('should yield string with string', () => {
-      should(defaults('lorem')).equal('lorem');
-    });
+        it('should yield string with string', () => {
+          should(env.get('TEST_LOREM', 'lorem').asString()).equal(tt.defaults[1]);
+          process.env.TEST_LOREM = 'test_lorem';
+          should(env.get('TEST_LOREM', 'lorem').asString()).equal('test_lorem');
+          delete process.env.TEST_LOREM;
+        });
 
-    it('should yield nothing with empty array', () => {
-      should(defaults([])).equal(undefined);
-    });
+        it('should yield nothing with empty array', () => {
+          should(env.get('TEST_LOREM', []).asString()).equal(tt.defaults[2]);
+          process.env.TEST_LOREM = 'test_lorem';
+          should(env.get('TEST_LOREM', []).asString()).equal('test_lorem');
+          delete process.env.TEST_LOREM;
+        });
 
-    it('should yield value with an array', () => {
-      should(defaults(['lorem'])).equal(undefined);
-    });
+        it('should yield value with an array', () => {
+          should(env.get('TEST_LOREM', ['lorem']).asString()).equal(tt.defaults[3]);
+          process.env.TEST_LOREM = 'test_lorem';
+          should(env.get('TEST_LOREM', ['lorem']).asString()).equal('test_lorem');
+          delete process.env.TEST_LOREM;
+        });
 
-    it('should yield value with an array', () => {
-      should(defaults(['ipsum', 'dolor'])).equal('dolor');
-    });
-  });
-
-  describe('The injected with default arguments and test env', () => {
-    let env;
-
-    before(() => {
-      process.env.NODE_ENV = 'test';
-      env = injected();
-    });
-
-    after(() => {
-      process.env.NODE_ENV = NODE_ENV;
-    });
-
-    it('should yield nothing with nothing', () => {
-      should(env.get('TEST_LOREM').asString()).equal(undefined);
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM').asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield string with string', () => {
-      should(env.get('TEST_LOREM', 'lorem').asString()).equal('lorem');
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', 'lorem').asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield nothing with empty array', () => {
-      should(env.get('TEST_LOREM', []).asString()).equal(undefined);
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', []).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield value with an array', () => {
-      should(env.get('TEST_LOREM', ['lorem']).asString()).equal('lorem');
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', ['lorem']).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield value with an array', () => {
-      should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal('ipsum');
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-  });
-
-  describe('The injected with default arguments and development env', () => {
-    let env;
-
-    before(() => {
-      process.env.NODE_ENV = 'development';
-      env = injected();
-    });
-
-    after(() => {
-      process.env.NODE_ENV = NODE_ENV;
-    });
-
-    it('should yield nothing with nothing', () => {
-      should(env.get('TEST_LOREM').asString()).equal(undefined);
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM').asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield string with string', () => {
-      should(env.get('TEST_LOREM', 'lorem').asString()).equal('lorem');
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', 'lorem').asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield nothing with empty array', () => {
-      should(env.get('TEST_LOREM', []).asString()).equal(undefined);
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', []).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield value with an array', () => {
-      should(env.get('TEST_LOREM', ['lorem']).asString()).equal(undefined);
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', ['lorem']).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
-
-    it('should yield value with an array', () => {
-      should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal('dolor');
-      process.env.TEST_LOREM = 'test_lorem';
-      should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal('test_lorem');
-      delete process.env.TEST_LOREM;
-    });
+        it('should yield value with an array', () => {
+          should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal(tt.defaults[4]);
+          process.env.TEST_LOREM = 'test_lorem';
+          should(env.get('TEST_LOREM', ['ipsum', 'dolor']).asString()).equal('test_lorem');
+          delete process.env.TEST_LOREM;
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
use the same test data for `default` and `injected` tests, added the two missing `staging` and `production` environments to the test setup